### PR TITLE
Tidy up code in various ways

### DIFF
--- a/Representations.lean
+++ b/Representations.lean
@@ -1,1 +1,4 @@
 import Representations.DihedralGroup
+import Representations.RealRepDn
+import Representations.Quaternion
+import Representations.RegRep

--- a/Representations/DihedralGroup.lean
+++ b/Representations/DihedralGroup.lean
@@ -22,7 +22,11 @@ lemma r_one_pow_cast (i : ZMod n) :
 
 end MissingLemmas
 
-/-! # The Relations
+/-!
+# Presentation
+In this section, we prove that `DihedralGroup n` has the presentation $\langle r, s : r^n = 1, s^2 = 1, rsr = s \rangle$.
+
+## Relations
 Here, we prove (or demonstrate that Mathlib has already proved) that the relations hold in the dihedral group and for any homomorphism out of the dihedral group.
 -/
 example : (DihedralGroup.r 1 : DihedralGroup n) ^ n = 1 :=
@@ -53,7 +57,7 @@ lemma r_mul_sr_mul_r (i j : ZMod n) :
   rwa [sub_self i, add_zero j] at this
 
 /-!
-# Lifting
+## Lifting
 Here, we construct the homomorphism out of the dihedral group into another group corresponding to given elements satisfying the relations.
 
 We also show that the two constructions are inverse, defining an equivalence between homomorphisms and elements satisfying the relations.
@@ -236,6 +240,7 @@ def homEquiv : (DihedralGroup n →* G) ≃ PresentationData n G where
 
 end UniversalProperty
 
+/-! # Construction of standard 2-dimensional representations -/
 section Real2DRepresentation
 
 -- how to work with points in (Fin 2 → ℝ)

--- a/Representations/DihedralGroup.lean
+++ b/Representations/DihedralGroup.lean
@@ -239,16 +239,16 @@ end UniversalProperty
 section Real2DRepresentation
 
 -- how to work with points in (Fin 2 → ℝ)
-def v : Fin 2 → ℝ := ![1, 0]
+example : Fin 2 → ℝ := ![1, 0]
 
-def u : Fin 2 → ℝ := fun i => if i = 0 then 1 else 0
+example : Fin 2 → ℝ := fun i => if i = 0 then 1 else 0
 
-def w : Fin 2 → ℝ := fun
+example : Fin 2 → ℝ := fun
   | 0 => 1
   | 1 => 0
 
 -- how to work with maps (Fin 2 → ℝ) → (Fin 2 → ℝ)
-def f : (Fin 2 → ℝ) → (Fin 2 → ℝ) :=
+example : (Fin 2 → ℝ) → (Fin 2 → ℝ) :=
   fun v => fun i => 2 * v i
 
 -- noncomputable def matrixToLin (M : GL (Fin 2) ℝ) : (Fin 2 → ℝ) →ₗ[ℝ] Fin 2 → ℝ where

--- a/Representations/DihedralGroup.lean
+++ b/Representations/DihedralGroup.lean
@@ -294,14 +294,17 @@ theorem rotationMatrix_pow (θ : ℝ) (l : ℕ) :
       ring_nf
     )
 
-theorem rotationMatrix_pow_n [NeZero n] (i : ℤ) :
+theorem rotationMatrix_pow_n (i : ℤ) :
     rotationMatrix (2 * π * i / n) ^ n = 1 := by
-  rw [rotationMatrix_pow]
-  have h₁ : cos (2 * π * i) = 1 := by
-    convert cos_int_mul_two_pi i using 2; ring
-  have h₂ : sin (2 * π * i) = 0 := by
-    convert sin_int_mul_pi (2 * i) using 2; push_cast; ring
-  ext i j; fin_cases i <;> fin_cases j <;> simpa
+  by_cases h:n = 0
+  · subst h; rfl
+  · haveI : NeZero n := ⟨h⟩
+    rw [rotationMatrix_pow]
+    have h₁ : cos (2 * π * i) = 1 := by
+      convert cos_int_mul_two_pi i using 2; ring
+    have h₂ : sin (2 * π * i) = 0 := by
+      convert sin_int_mul_pi (2 * i) using 2; push_cast; ring
+    ext i j; fin_cases i <;> fin_cases j <;> simpa
 
 abbrev reflectionMatrix /- (θ : ℝ) -/ : Matrix (Fin 2) (Fin 2) ℝ :=
   !![1,  0;
@@ -315,6 +318,13 @@ theorem reflectionMatrix_conj_rotationMatrix (θ : ℝ) :
     = rotationMatrix (-θ) := by
   rewrite [show reflectionMatrix⁻¹ = reflectionMatrix by unfold Matrix.inv; simp]
   ext i j; fin_cases i <;> fin_cases j <;> simp
+
+theorem rot_mul_refl_mul_rot_eq_refl (θ : ℝ) :
+    rotationMatrix θ * reflectionMatrix * rotationMatrix θ = reflectionMatrix := by
+  ext i j; fin_cases i <;> fin_cases j <;> unfold rotationMatrix reflectionMatrix
+  case «0».«0» => simp [←pow_two, cos_sq_add_sin_sq θ]
+  case «1».«1» => have := congrArg Neg.neg (cos_sq_add_sin_sq θ); simp_all [pow_two]
+  case «0».«1» | «1».«0» => simp [mul_comm]
 
 -- example of obtaining an element of GL given a matrix and proof of invertibility
 noncomputable example (t : Matrix (Fin 2) (Fin 2) ℝ) (h : IsUnit t) : GL (Fin 2) ℝ := h.unit
@@ -362,7 +372,7 @@ lemma rotationMatrix_unit_pow (θ : ℝ) (l : ℕ) :
   rw [Units.ext_iff]
   exact rotationMatrix_pow θ l
 
-theorem rotationMatrix_unit_pow_n [NeZero n] (i : ℤ) :
+theorem rotationMatrix_unit_pow_n (i : ℤ) :
     rotationMatrix_unit (2 * π * i / n) ^ n = 1 := by
   dsimp [rotationMatrix_unit]
   rw [Units.ext_iff]
@@ -385,6 +395,11 @@ lemma conj_unit_relation :
   dsimp [reflectionMatrix_unit, rotationMatrix_unit]
   rw [Units.ext_iff]
   exact conj_relation
+
+theorem rot_mul_refl_mul_rot_eq_refl_unit (θ : ℝ) :
+    rotationMatrix_unit θ * reflectionMatrix_unit * rotationMatrix_unit θ
+    = reflectionMatrix_unit := by
+  ext : 1; push_cast; exact rot_mul_refl_mul_rot_eq_refl θ
 
 noncomputable def representation :
     Representation ℝ (DihedralGroup n) (Fin 2 → ℝ) := by

--- a/Representations/DihedralGroup.lean
+++ b/Representations/DihedralGroup.lean
@@ -326,6 +326,8 @@ theorem rot_mul_refl_mul_rot_eq_refl (θ : ℝ) :
   case «1».«1» => have := congrArg Neg.neg (cos_sq_add_sin_sq θ); simp_all [pow_two]
   case «0».«1» | «1».«0» => simp [mul_comm]
 
+section GLApproach
+
 -- example of obtaining an element of GL given a matrix and proof of invertibility
 noncomputable example (t : Matrix (Fin 2) (Fin 2) ℝ) (h : IsUnit t) : GL (Fin 2) ℝ := h.unit
 
@@ -436,6 +438,8 @@ noncomputable def representation :
   let φ := lift h_a h_b h_ab
   exact ((DistribMulAction.toModuleEnd ℝ (Fin 2 → ℝ)).comp
     Matrix.GeneralLinearGroup.toLin.toMonoidHom).comp φ
+
+end GLApproach
 
 end Real2DRepresentation
 

--- a/Representations/DihedralGroup.lean
+++ b/Representations/DihedralGroup.lean
@@ -83,10 +83,6 @@ lemma hom_relation₃' [Group G] (f : DihedralGroup n →* G) :
   rw [sr_conj_r, DihedralGroup.inv_r]
 -/
 
--- example {G H} [Group G] [Monoid H] (f : G →* H) (x : G) (n : ℤ) : f (x ^ n) = _ := sorry
-
-example {G H} [Group G] [Monoid H] (f : G →* H) : G →* Hˣ := f.toHomUnits
-
 -- These are dangerous as simp lemmas for some reason related to applying it to Gˣˣˣ...
 lemma hom_apply_r (i : ZMod n) :
     (f (.r i) : G) = ((f.toHomUnits (.r 1)) ^ (i.cast : ℤ) : Gˣ) := by

--- a/Representations/DihedralGroup.lean
+++ b/Representations/DihedralGroup.lean
@@ -293,9 +293,9 @@ theorem rotationMatrix_pow_n [NeZero n] (i : ℤ) :
     rotationMatrix (2 * π * i / n) ^ n = 1 := by
   rw [rotationMatrix_pow]
   have h₁ : cos (2 * π * i) = 1 := by
-    convert cos_int_mul_two_pi i using 2; ring_nf
+    convert cos_int_mul_two_pi i using 2; ring
   have h₂ : sin (2 * π * i) = 0 := by
-    convert sin_int_mul_pi (2 * i) using 2; push_cast; ring_nf
+    convert sin_int_mul_pi (2 * i) using 2; push_cast; ring
   ext i j; fin_cases i <;> fin_cases j <;> simpa
 
 abbrev reflectionMatrix /- (θ : ℝ) -/ : Matrix (Fin 2) (Fin 2) ℝ :=
@@ -370,30 +370,8 @@ lemma conj_relation :
   ext i j
   simp
   fin_cases i <;> fin_cases j
-  . simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, Matrix.one_apply_eq]
-    -- i = 0, j = 0
-    rw [← pow_two]
-    rw [← pow_two]
-    simp only [cos_sq_add_sin_sq]
-
-  . simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one,
-               Matrix.cons_val_fin_one, Fin.zero_eta, Matrix.cons_val_zero,
-               ne_eq, zero_ne_one, not_false_eq_true, Matrix.one_apply_ne]
-    -- i = 0 j = 1
-    ring
-
-  . simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, Fin.mk_one,
-               Matrix.cons_val_one, ne_eq, one_ne_zero, not_false_eq_true,
-               Matrix.one_apply_ne]
-    -- i = 1, j = 0
-    ring
-
-  . simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one,
-               Matrix.cons_val_fin_one, Matrix.one_apply_eq]
-    -- i = 1, j = 1
-    rw [← pow_two]
-    rw [← pow_two]
-    simp only [sin_sq_add_cos_sq]
+  case «0».«0» | «1».«1» => simp [←pow_two, cos_sq_add_sin_sq]
+  case «0».«1» | «1».«0» => ring_nf; simp
 
 lemma conj_unit_relation :
     reflectionMatrix_unit * rotationMatrix_unit (2 * π / ↑n) *
@@ -409,14 +387,12 @@ noncomputable def representation :
   let G := GL (Fin 2) ℝ
   let r : G := rotationMatrix_unit (2 * π / n)
   let s : G := reflectionMatrix_unit
-  let h_a : r ^ n = 1 := by
+  have h_a : r ^ n = 1 := by
     cases Nat.eq_zero_or_pos n with
-      | inl h_zero  => exact
-        pow_eq_one_iff_modEq.mpr (congrFun (congrArg HMod.hMod h_zero) (orderOf r))
+      | inl h_zero  => rw [pow_eq_one_iff_modEq, h_zero]
 
       | inr h_pos =>
-        have h_nezero: NeZero n := by
-          exact NeZero.of_pos h_pos
+        haveI : NeZero n := NeZero.of_pos h_pos
 
         unfold r
         --have hmodify : rotationMatrix_unit (2 * π / n) ^ n
@@ -431,10 +407,8 @@ noncomputable def representation :
         rw [← hl2]
         rw [rotationMatrix_unit_pow_n (1 : ℤ)]
 
-  let h_b : s * s = 1 := by
-    simp [s]
-    exact reflectionMatrix_unit_mul_self
-  let h_ab : r * s * r = s := by
+  have h_b : s * s = 1 := reflectionMatrix_unit_mul_self
+  have h_ab : r * s * r = s := by
     unfold r s
     symm; rewrite [←inv_mul_eq_one, reflectionMatrix_unit_eq_inv_self]
     simp only [←mul_assoc] -- left-associate

--- a/Representations/DihedralGroup.lean
+++ b/Representations/DihedralGroup.lean
@@ -33,22 +33,22 @@ example : (DihedralGroup.sr 0 : DihedralGroup n) * DihedralGroup.sr 0 = 1 :=
 
 lemma sr_conj_r (i j : ZMod n) :
     (DihedralGroup.sr i : DihedralGroup n) *
-      DihedralGroup.r j * (DihedralGroup.sr i)⁻¹ =
-    DihedralGroup.r (-j) :=
+        DihedralGroup.r j * (DihedralGroup.sr i)⁻¹
+    = DihedralGroup.r (-j) :=
   show DihedralGroup.r (i - (i + j)) = DihedralGroup.r (-j) by
   abel_nf
 
 lemma r_mul_sr_mul_r' (i j k : ZMod n) :
     (DihedralGroup.r i : DihedralGroup n) *
-      DihedralGroup.sr j * DihedralGroup.r k =
-    DihedralGroup.sr (j + (k - i)) :=
+        DihedralGroup.sr j * DihedralGroup.r k
+    = DihedralGroup.sr (j + (k - i)) :=
   show DihedralGroup.sr (j - i + k) = DihedralGroup.sr (j + (k - i)) by
   abel_nf
 
 lemma r_mul_sr_mul_r (i j : ZMod n) :
     (DihedralGroup.r i : DihedralGroup n) *
-      DihedralGroup.sr j * DihedralGroup.r i =
-    DihedralGroup.sr j := by
+        DihedralGroup.sr j * DihedralGroup.r i
+    = DihedralGroup.sr j := by
   have := r_mul_sr_mul_r' i j i
   rwa [sub_self i, add_zero j] at this
 
@@ -105,8 +105,10 @@ variable {r s : G} (h_r : r ^ n = 1) (h_s : s * s = 1) (h_rs : r * s * r = s)
 private def lift.r_ : Gˣ where
   val := r
   inv := s * r * s
-  val_inv := by rewrite [←mul_assoc, ←mul_assoc]; rw [h_rs, h_s]
-  inv_val := by rewrite [mul_assoc, mul_assoc]; nth_rewrite 2 [←mul_assoc]; rw [h_rs, h_s]
+  val_inv := by rewrite [←mul_assoc, ←mul_assoc]
+                rw [h_rs, h_s]
+  inv_val := by rewrite [mul_assoc, mul_assoc]; nth_rewrite 2 [←mul_assoc]
+                rw [h_rs, h_s]
 
 private def lift.s_ : Gˣ := ⟨s, s, h_s, h_s⟩
 
@@ -265,7 +267,7 @@ noncomputable example : GL (Fin 2) ℝ →* (Fin 2 → ℝ) ≃ₗ[ℝ] Fin 2 �
   exact w.toMonoidHom
 
 noncomputable example : GL (Fin 2) ℝ →* (Fin 2 → ℝ) →ₗ[ℝ] Fin 2 → ℝ := by
-  let e : LinearMap.GeneralLinearGroup ℝ (Fin 2 → ℝ) →*  ((Fin 2 → ℝ) →ₗ[ℝ] Fin 2 → ℝ) :=
+  let e : LinearMap.GeneralLinearGroup ℝ (Fin 2 → ℝ) →* Module.End ℝ (Fin 2 → ℝ) :=
     DistribMulAction.toModuleEnd ℝ (Fin 2 → ℝ)
   let u := Matrix.GeneralLinearGroup.toLin (n := Fin 2) (R := ℝ)
   exact e.comp u.toMonoidHom
@@ -308,7 +310,8 @@ theorem reflectionMatrix_mul_self : reflectionMatrix * reflectionMatrix = 1 := b
   ext i j; fin_cases i <;> fin_cases j <;> simp
 
 theorem reflectionMatrix_conj_rotationMatrix (θ : ℝ) :
-    reflectionMatrix * rotationMatrix θ * reflectionMatrix⁻¹ = (rotationMatrix (-θ)) := by
+    reflectionMatrix * rotationMatrix θ * reflectionMatrix⁻¹
+    = rotationMatrix (-θ) := by
   rewrite [show reflectionMatrix⁻¹ = reflectionMatrix by unfold Matrix.inv; simp]
   ext i j; fin_cases i <;> fin_cases j <;> simp
 
@@ -325,12 +328,14 @@ lemma reflectionMatrix_is_unit : IsUnit reflectionMatrix := by
 noncomputable def reflectionMatrix_unit : GL (Fin 2) ℝ :=
     reflectionMatrix_is_unit.unit
 
-lemma reflectionMatrix_unit_mul_self : reflectionMatrix_unit * reflectionMatrix_unit = 1 := by
+lemma reflectionMatrix_unit_mul_self :
+    reflectionMatrix_unit * reflectionMatrix_unit = 1 := by
   dsimp [reflectionMatrix_unit]
   rw [Units.ext_iff]
   exact reflectionMatrix_mul_self
 
-lemma reflectionMatrix_unit_eq_inv_self : reflectionMatrix_unit⁻¹ = reflectionMatrix_unit := by
+lemma reflectionMatrix_unit_eq_inv_self :
+    reflectionMatrix_unit⁻¹ = reflectionMatrix_unit := by
   rw [@inv_eq_iff_mul_eq_one]
   exact reflectionMatrix_unit_mul_self
 
@@ -350,54 +355,60 @@ noncomputable def rotationMatrix_unit (θ : ℝ): GL (Fin 2) ℝ := by
   have h : IsUnit (rotationMatrix (θ : ℝ)):= by exact rotM_isUnit θ
   exact h.unit
 
-lemma rotationMatrix_unit_pow (θ : ℝ) (l : ℕ) : (rotationMatrix_unit θ) ^ l = rotationMatrix_unit (θ * l) := by
+lemma rotationMatrix_unit_pow (θ : ℝ) (l : ℕ) :
+    (rotationMatrix_unit θ) ^ l = rotationMatrix_unit (θ * l) := by
   dsimp [rotationMatrix_unit]
   rw [Units.ext_iff]
   exact rotationMatrix_pow θ l
 
-theorem rotationMatrix_unit_pow_n [NeZero n] (i : ℤ) :  rotationMatrix_unit (2 * π * i / n) ^ n = 1 := by
+theorem rotationMatrix_unit_pow_n [NeZero n] (i : ℤ) :
+    rotationMatrix_unit (2 * π * i / n) ^ n = 1 := by
   dsimp [rotationMatrix_unit]
   rw [Units.ext_iff]
   exact rotationMatrix_pow_n i
 
-lemma conj_relation : reflectionMatrix * rotationMatrix (2 * π / ↑n)
-    * reflectionMatrix * rotationMatrix (2 * π / ↑n) = 1 := by
+lemma conj_relation :
+    reflectionMatrix * rotationMatrix (2 * π / ↑n) *
+        reflectionMatrix * rotationMatrix (2 * π / ↑n)
+    = 1 := by
   ext i j
   simp
-  fin_cases i
-  . fin_cases j
-    . simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, Matrix.one_apply_eq]
-      -- i = 0, j = 0
-      rw [← pow_two]
-      rw [← pow_two]
-      simp only [cos_sq_add_sin_sq]
+  fin_cases i <;> fin_cases j
+  . simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, Matrix.one_apply_eq]
+    -- i = 0, j = 0
+    rw [← pow_two]
+    rw [← pow_two]
+    simp only [cos_sq_add_sin_sq]
 
-    . simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      Fin.zero_eta, Matrix.cons_val_zero, ne_eq, zero_ne_one, not_false_eq_true,
-      Matrix.one_apply_ne]
-      -- i = 0 j = 1
-      ring
+  . simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one,
+               Matrix.cons_val_fin_one, Fin.zero_eta, Matrix.cons_val_zero,
+               ne_eq, zero_ne_one, not_false_eq_true, Matrix.one_apply_ne]
+    -- i = 0 j = 1
+    ring
 
-  . fin_cases j
-    . simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, Fin.mk_one, Matrix.cons_val_one,
-      ne_eq, one_ne_zero, not_false_eq_true, Matrix.one_apply_ne]
-      -- i = 1, j = 0
-      ring
+  . simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, Fin.mk_one,
+               Matrix.cons_val_one, ne_eq, one_ne_zero, not_false_eq_true,
+               Matrix.one_apply_ne]
+    -- i = 1, j = 0
+    ring
 
-    . simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      Matrix.one_apply_eq]
-      -- i = 1, j = 1
-      rw [← pow_two]
-      rw [← pow_two]
-      simp only [sin_sq_add_cos_sq]
+  . simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one,
+               Matrix.cons_val_fin_one, Matrix.one_apply_eq]
+    -- i = 1, j = 1
+    rw [← pow_two]
+    rw [← pow_two]
+    simp only [sin_sq_add_cos_sq]
 
-lemma conj_unit_relation : reflectionMatrix_unit * rotationMatrix_unit (2 * π / ↑n)
-    * reflectionMatrix_unit * rotationMatrix_unit (2 * π / ↑n) = 1 := by
+lemma conj_unit_relation :
+    reflectionMatrix_unit * rotationMatrix_unit (2 * π / ↑n) *
+        reflectionMatrix_unit * rotationMatrix_unit (2 * π / ↑n)
+    = 1 := by
   dsimp [reflectionMatrix_unit, rotationMatrix_unit]
   rw [Units.ext_iff]
   exact conj_relation
 
-noncomputable def representation : Representation ℝ (DihedralGroup n) (Fin 2 → ℝ) := by
+noncomputable def representation :
+    Representation ℝ (DihedralGroup n) (Fin 2 → ℝ) := by
   dsimp [Representation]
   let G := GL (Fin 2) ℝ
   let r : G := rotationMatrix_unit (2 * π / n)
@@ -412,10 +423,12 @@ noncomputable def representation : Representation ℝ (DihedralGroup n) (Fin 2 �
           exact NeZero.of_pos h_pos
 
         unfold r
-        --have hmodify : rotationMatrix_unit (2 * π / n) ^ n = rotationMatrix_unit (2 * π * 1 / n) ^ n := by
+        --have hmodify : rotationMatrix_unit (2 * π / n) ^ n
+        --               = rotationMatrix_unit (2 * π * 1 / n) ^ n := by
         --  simp only [mul_one]
         --rw [hmodify]
-        have hl2: rotationMatrix_unit (2 * π * (1 : ℤ)/ ↑n) ^ n = rotationMatrix_unit (2 * π / ↑n) ^ n := by
+        have hl2 : rotationMatrix_unit (2 * π * (1 : ℤ)/ ↑n) ^ n
+                   = rotationMatrix_unit (2 * π / ↑n) ^ n := by
           have h: 2 * π * (1: ℤ) / n = 2 * π / n := by
             simp only [Int.cast_one, mul_one]
           rw [h]

--- a/Representations/DihedralGroup.lean
+++ b/Representations/DihedralGroup.lean
@@ -401,7 +401,7 @@ noncomputable def representation :
         --rw [hmodify]
         have hl2 : rotationMatrix_unit (2 * π * (1 : ℤ)/ ↑n) ^ n
                    = rotationMatrix_unit (2 * π / ↑n) ^ n := by
-          have h: 2 * π * (1: ℤ) / n = 2 * π / n := by
+          have h : 2 * π * (1: ℤ) / n = 2 * π / n := by
             simp only [Int.cast_one, mul_one]
           rw [h]
         rw [← hl2]

--- a/Representations/Quaternion.lean
+++ b/Representations/Quaternion.lean
@@ -3,7 +3,8 @@ import Mathlib.Tactic.NoncommRing
 
 variable (n: ℕ) (G: Type*) [Monoid G]
 
-example {G': Type*} [Group G'] {a: G'} {a_pow_n_eq_one: a^n = 1} {k l: ℕ} : k ≡ l [ZMOD n] → a^k = a^l := by
+example {G': Type*} [Group G'] {a: G'} {a_pow_n_eq_one: a^n = 1} {k l: ℕ} :
+    k ≡ l [ZMOD n] → a^k = a^l := by
   intro h
   refine pow_eq_pow_iff_modEq.mpr ?_
   apply Int.natCast_modEq_iff.mp
@@ -12,14 +13,16 @@ example {G': Type*} [Group G'] {a: G'} {a_pow_n_eq_one: a^n = 1} {k l: ℕ} : k 
   rw [kh] at h
   simpa using Int.ModEq.of_mul_right k h
 
-lemma pow_eq_pow_of_ModEq {G: Type*} [Monoid G] {a: G} {i j n: ℕ} (h₁: a^n = 1) (h₂: i ≡ j [MOD n]) : a^i = a^j := by
+lemma pow_eq_pow_of_ModEq {G: Type*} [Monoid G] {a: G} {i j n: ℕ}
+    (h₁: a^n = 1) (h₂: i ≡ j [MOD n]) : a^i = a^j := by
   wlog i_le_j: i ≤ j
   · exact (this h₁ h₂.symm $ le_of_not_ge i_le_j).symm
   · let ⟨k, hk⟩ := (Nat.modEq_iff_dvd' i_le_j).mp h₂
     apply Nat.eq_add_of_sub_eq i_le_j at hk
     simp [hk, pow_add, pow_mul, h₁]
 
-lemma rel_two_eq_xa {G: Type*} [Monoid G] {a x: G} {n: ℕ} [NeZero n] {i j: ZMod n} (h₁: a^n = 1) (h₂: a * x * a = x): 
+lemma rel_two_eq_xa {G: Type*} [Monoid G] {a x: G} {n: ℕ} [NeZero n] {i j: ZMod n}
+    (h₁: a^n = 1) (h₂: a * x * a = x):
     a^i.val * x * a^j.val = x * a^(j - i).val := by
   if n_one: n = 1 then
     subst n_one
@@ -57,7 +60,8 @@ lemma rel_two_eq_xa {G: Type*} [Monoid G] {a x: G} {n: ℕ} [NeZero n] {i j: ZMo
 
 termination_by i.val
 
-def QuaternionGroup.lift [NeZero n] (a x: G) (h₁: a^(2 * n) = 1) (h₂: x^2 = a^n) (h₃: a * x * a = x):
+def QuaternionGroup.lift [NeZero n] (a x: G)
+    (h₁: a^(2 * n) = 1) (h₂: x^2 = a^n) (h₃: a * x * a = x):
     QuaternionGroup n →* G where
   toFun := fun g => match g with
     | .a k => a ^ k.val
@@ -73,7 +77,7 @@ def QuaternionGroup.lift [NeZero n] (a x: G) (h₁: a^(2 * n) = 1) (h₂: x^2 = 
 
     case' a.a => rw [<-pow_add]
     case' xa.a => rw [(?_: a^(l + m).val = a^(l.val + m.val)), mul_assoc, <-pow_add]
-    case a.a | xa.a => exact pow_eq_pow_of_ModEq h₁ (by simp [<-ZMod.eq_iff_modEq_nat])
+    case a.a | xa.a => apply pow_eq_pow_of_ModEq h₁; simp [←ZMod.eq_iff_modEq_nat]
 
     · rw [<-mul_assoc, <-rel_two_eq_xa h₁ h₃]
     · conv_rhs => calc x * a^l.val * (x * a^m.val)
@@ -85,4 +89,3 @@ def QuaternionGroup.lift [NeZero n] (a x: G) (h₁: a^(2 * n) = 1) (h₂: x^2 = 
       apply pow_eq_pow_of_ModEq h₁
       simp [<-ZMod.eq_iff_modEq_nat]
       ring
-

--- a/Representations/Quaternion.lean
+++ b/Representations/Quaternion.lean
@@ -1,6 +1,5 @@
-import Representations.Basic
-
-import Mathlib
+import Mathlib.GroupTheory.SpecificGroups.Quaternion
+import Mathlib.Tactic.NoncommRing
 
 variable (n: ℕ) (G: Type*) [Monoid G]
 
@@ -58,7 +57,7 @@ lemma rel_two_eq_xa {G: Type*} [Monoid G] {a x: G} {n: ℕ} [NeZero n] {i j: ZMo
 
 termination_by i.val
 
-def lift [NeZero n] (a x: G) (h₁: a^(2 * n) = 1) (h₂: x^2 = a^n) (h₃: a * x * a = x):
+def QuaternionGroup.lift [NeZero n] (a x: G) (h₁: a^(2 * n) = 1) (h₂: x^2 = a^n) (h₃: a * x * a = x):
     QuaternionGroup n →* G where
   toFun := fun g => match g with
     | .a k => a ^ k.val

--- a/Representations/RealRepDn.lean
+++ b/Representations/RealRepDn.lean
@@ -1,6 +1,9 @@
 -- work by Hikari Iwasaki on June 24, 2025 --
-import Mathlib
-#check DihedralGroup
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.GroupTheory.SpecificGroups.Dihedral
+import Mathlib.RepresentationTheory.Basic
+
+-- #check DihedralGroup
 
 noncomputable section
 
@@ -31,7 +34,7 @@ def rotMat (n : ℕ) : Matrix (Fin 2) (Fin 2) ℝ :=
    Real.sin (2 * Real.pi / n),
    Real.cos (2 * Real.pi / n)]
 
-#check Real.cos_add --  cos (x + y) = cos x * cos y - sin x * sin y
+-- #check Real.cos_add -- cos (x + y) = cos x * cos y - sin x * sin y
 
 
 theorem rot_l (n l : ℕ): (rotMat n)^l  = !![Real.cos (2 * Real.pi * l/ n),
@@ -119,7 +122,7 @@ theorem ref_ref_id : refMat * refMat  = 1:= by
     fin_cases j <;>  simp }
 
 
-#check Nat.zero_le
+-- #check Nat.zero_le
 theorem ref_rot_gen (n: ℕ)  (hn : n ≠ 0): ∀ l', (l' < n) → (rotMat n)^l' = refMat * (rotMat n)^(n-l') * refMat  := by
   intro l' hl'
   induction' l' with l' ih
@@ -181,8 +184,8 @@ theorem stdmap_one (n : ℕ): stdmap n 1 = 1 := by
   simp
   rfl
 
-#check LinearMap.toMatrix'_comp
-#check Matrix.toLin'_mul
+-- #check LinearMap.toMatrix'_comp
+-- #check Matrix.toLin'_mul
 
 
 theorem stdmap_mul (n: ℕ) (hn : n ≠ 0): ∀ x y , stdmap n (x * y) = stdmap n x ∘ₗ stdmap n y := by

--- a/Representations/RealRepDn.lean
+++ b/Representations/RealRepDn.lean
@@ -83,7 +83,8 @@ theorem rot_id_pow (n : ℕ) (hn : n ≠ 0): ∀ (l : ℕ), (rotMat n)^(n * l) =
 def refMat : Matrix (Fin 2) (Fin 2) ℝ :=
   !![1 , 0 ; 0,  -1]
 
-theorem ref_rot (n: ℕ)  (hn : n ≠ 0): (rotMat n) * refMat = refMat * (rotMat n)^(n-1) := by
+theorem ref_rot (n: ℕ)  (hn : n ≠ 0):
+    (rotMat n) * refMat = refMat * (rotMat n)^(n-1) := by
   rw [rot_l]
   unfold rotMat refMat
   ext i j
@@ -99,7 +100,8 @@ theorem ref_rot (n: ℕ)  (hn : n ≠ 0): (rotMat n) * refMat = refMat * (rotMat
   }
 
 
-theorem ref_rot' (n: ℕ)  (hn : n ≠ 0): (rotMat n)^(n-1) * refMat = refMat * rotMat n := by
+theorem ref_rot' (n: ℕ)  (hn : n ≠ 0):
+    (rotMat n)^(n-1) * refMat = refMat * rotMat n := by
   rw [rot_l]
   unfold rotMat refMat
   ext i j
@@ -123,7 +125,8 @@ theorem ref_ref_id : refMat * refMat  = 1:= by
 
 
 -- #check Nat.zero_le
-theorem ref_rot_gen (n: ℕ)  (hn : n ≠ 0): ∀ l', (l' < n) → (rotMat n)^l' = refMat * (rotMat n)^(n-l') * refMat  := by
+theorem ref_rot_gen (n: ℕ)  (hn : n ≠ 0):
+    ∀ l', (l' < n) → (rotMat n)^l' = refMat * (rotMat n)^(n-l') * refMat  := by
   intro l' hl'
   induction' l' with l' ih
   · rw [pow_zero, tsub_zero, rot_id n hn, mul_one, ref_ref_id]
@@ -154,7 +157,8 @@ theorem ref_rot_gen (n: ℕ)  (hn : n ≠ 0): ∀ l', (l' < n) → (rotMat n)^l'
     contradiction
 
 
-theorem ref_rot_id (n: ℕ)  (hn : n ≠ 0): ∀ (l : ℕ), refMat * (rotMat n)^l * refMat * (rotMat n)^l = 1 := by
+theorem ref_rot_id (n: ℕ)  (hn : n ≠ 0):
+    ∀ (l : ℕ), refMat * (rotMat n)^l * refMat * (rotMat n)^l = 1 := by
   intro l
   induction' l with l ih
   · simp
@@ -188,7 +192,8 @@ theorem stdmap_one (n : ℕ): stdmap n 1 = 1 := by
 -- #check Matrix.toLin'_mul
 
 
-theorem stdmap_mul (n: ℕ) (hn : n ≠ 0): ∀ x y , stdmap n (x * y) = stdmap n x ∘ₗ stdmap n y := by
+theorem stdmap_mul (n: ℕ) (hn : n ≠ 0):
+    ∀ x y, stdmap n (x * y) = stdmap n x ∘ₗ stdmap n y := by
   haveI : NeZero n := ⟨hn⟩
   intro x y
   match y with
@@ -258,7 +263,8 @@ theorem stdmap_mul (n: ℕ) (hn : n ≠ 0): ∀ x y , stdmap n (x * y) = stdmap 
 
       push_neg at h
       have : m.val + k.val = (m + k).val + n := ZMod.val_add_val_of_le h
-      rw [← mul_one ((rotMat n) ^ ((m + k).val)), ← rot_id n hn, ← pow_add, ←this, add_comm, pow_add]
+      rw [← mul_one ((rotMat n) ^ ((m + k).val)), ← rot_id n hn, ← pow_add,
+          ←this, add_comm, pow_add]
       repeat rw [← mul_assoc]
       congr 1
       nth_rw 1 [← one_mul ((rotMat n)^ k.val), ← ref_ref_id, ← mul_one refMat]
@@ -295,7 +301,8 @@ theorem stdmap_mul (n: ℕ) (hn : n ≠ 0): ∀ x y , stdmap n (x * y) = stdmap 
 
       push_neg at h
       have : m.val + k.val = (m + k).val + n := ZMod.val_add_val_of_le h
-      rw [← mul_one ((rotMat n) ^ ((m + k).val)), ← rot_id n hn, ← pow_add, ←this, add_comm, pow_add]
+      rw [← mul_one ((rotMat n) ^ ((m + k).val)), ← rot_id n hn, ← pow_add,
+          ←this, add_comm, pow_add]
       repeat rw [← mul_assoc]
       rw [ref_rot_id n hn k.val, one_mul]
 

--- a/Representations/RegRep.lean
+++ b/Representations/RegRep.lean
@@ -1,7 +1,8 @@
-import Mathlib
-
 -- Work by Hikari Iwasaki, Wednesday-Thursday June 25-26, 2025
--- Regular representaiton over ℝ. There should be no problem extending this to an arbitrary field k.
+import Mathlib.Data.Real.Basic
+import Mathlib.RepresentationTheory.Basic
+
+-- Regular representation over ℝ. There should be no problem extending this to an arbitrary field k.
 
 noncomputable section
 


### PR DESCRIPTION
Tidy up code: minimise imports, import all files in 'Representations.lean', split long lines, add some module docstrings, turn some declarations into examples, etc.